### PR TITLE
Farmer/products image hover

### DIFF
--- a/src/main/resources/static/css/styles.css
+++ b/src/main/resources/static/css/styles.css
@@ -1,5 +1,62 @@
 @charset "UTF-8";
 
+.top-rounded{
+  border-radius: .2rem .2rem 0px 0px;
+}
+
+.hover {
+  overflow: hidden;
+  position: relative;
+  padding-bottom: 85%;
+}
+
+.hover-overlay {
+  width: 100%;
+  height: 100%;
+  position: absolute;
+  top: 0;
+  left: 0;
+  z-index: 90;
+  transition: all 0.4s;
+}
+
+.hover img {
+  width: 100%;
+  position: absolute;
+  top: 0;
+  left: 0;
+  transition: all 0.3s;
+}
+
+.hover-content {
+  position: relative;
+  z-index: 99;
+}
+
+.hover-2 .hover-overlay {
+  background: linear-gradient(to top, rgba(0, 0, 0, 0.4), rgba(0, 0, 0, 0.1));
+}
+
+.hover-2-description {
+  width: 100%;
+  position: absolute;
+  bottom: 0;
+  opacity: 0;
+  left: 0;
+  text-align: center;
+  z-index: 99;
+  transition: all 0.3s;
+}
+
+.hover-2:hover .hover-2-description {
+  bottom: 42%; /* Best for one or two line descriptions. Character limit for descriptions maybe? */
+  opacity: 1;
+}
+
+.hover-2:hover .hover-overlay {
+  background: linear-gradient(to top, rgba(0, 0, 0, 0.9), rgba(0, 0, 0, 0.1));
+}
+
 .padding-right{
   padding-right: 10px;
 }

--- a/src/main/resources/templates/farmer/products.html
+++ b/src/main/resources/templates/farmer/products.html
@@ -26,7 +26,14 @@
                                 <span><i class=""></i></span>
                             </div>
                         </div>
-                        <img th:if="${currentProduct.productDetails.picture != null}" th:src="@{'/'+*{productDetails.picture}}" th:alt="*{name}" width="100%"/>
+<!--                        <img th:if="${currentProduct.productDetails.picture != null}" th:src="@{'/'+*{productDetails.picture}}" th:alt="*{name}" width="100%"/>-->
+                        <div class="hover hover-2 text-white top-rounded">
+                            <img th:if="${currentProduct.productDetails.picture != null}" th:src="@{'/'+*{productDetails.picture}}" th:alt="*{name}" width="100%" height="100%"/>
+                            <div class="hover-overlay"></div>
+                            <div class="hover-2-content px-5 py-4">
+                                <p class="hover-2-description text-uppercase mb-0" th:text="*{ProductDetails.description}"></p>
+                            </div>
+                        </div>
                     </div>
                     <div class="p-2">
                         <div class="d-flex justify-content-between align-items-center">

--- a/src/main/resources/templates/farmer/products.html
+++ b/src/main/resources/templates/farmer/products.html
@@ -26,7 +26,7 @@
                                 <span><i class=""></i></span>
                             </div>
                         </div>
-<!--                        <img th:if="${currentProduct.productDetails.picture != null}" th:src="@{'/'+*{productDetails.picture}}" th:alt="*{name}" width="100%"/>-->
+                        <!--                        <img th:if="${currentProduct.productDetails.picture != null}" th:src="@{'/'+*{productDetails.picture}}" th:alt="*{name}" width="100%"/>-->
                         <div class="hover hover-2 text-white top-rounded">
                             <img th:if="${currentProduct.productDetails.picture != null}" th:src="@{'/'+*{productDetails.picture}}" th:alt="*{name}" width="100%" height="100%"/>
                             <div class="hover-overlay"></div>

--- a/src/main/resources/templates/farmer/products.html
+++ b/src/main/resources/templates/farmer/products.html
@@ -26,7 +26,6 @@
                                 <span><i class=""></i></span>
                             </div>
                         </div>
-                        <!--                        <img th:if="${currentProduct.productDetails.picture != null}" th:src="@{'/'+*{productDetails.picture}}" th:alt="*{name}" width="100%"/>-->
                         <div class="hover hover-2 text-white top-rounded">
                             <img th:if="${currentProduct.productDetails.picture != null}" th:src="@{'/'+*{productDetails.picture}}" th:alt="*{name}" width="100%" height="100%"/>
                             <div class="hover-overlay"></div>


### PR DESCRIPTION
Added hover-over image functionality to farmer/products. Hovering over images now shows item descriptions. Currently, long descriptions don't show correctly. Made a slight tweak to item picture display: top corners are now rounded while the bottom corners are flat to better line up with card.